### PR TITLE
Provide basic macOS support #30

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -26,7 +26,7 @@ jobs:
         include:
           - os: ubuntu-latest
           - os: windows-latest
-          # - os: macos-latest
+          - os: macos-latest
 
     steps:
       - name: Checkout repository

--- a/extension/src/setup/install.scss
+++ b/extension/src/setup/install.scss
@@ -10,7 +10,7 @@
 //////////////////////////////
 
 .wrapper {
-  max-width: 64rem;
+  max-width: 67rem;
 }
 
 .card {

--- a/extension/src/setup/instructions.html
+++ b/extension/src/setup/instructions.html
@@ -65,9 +65,34 @@
           <p>For a list of commands to do this, check <a href="https://github.com/filips123/FirefoxPWA/tree/main/native#other-linux">the README file in the repository</a>.</p>
         </div>
         <div class="tab-pane fade" id="macos-install-pane" role="tabpanel" aria-labelledby="macos-install-tab">
+          <p>⚠️ On macOS there is no automatic installer yet. The connector has to be built from source! ⚠️</p>
           <p>
-            macOS is currently not supported. Any help to add support for it would be appreciated.
+            ⚠️ macOS is not yet fully supported!
+            There is currently no proper system integration (**no** Icon in your application list, **no** correct icon when you launch the PWA, windows are **not** seperated by PWA).
+            Follow #33 to get updated on this issue. ⚠️
           </p>
+          <ol>
+            <li>Clone the <a href="https://github.com/filips123/FirefoxPWA">FirefoxPWA Git repository</a> and <kbd>cd</kbd> into the <kbd>native</kbd> directory.</li>
+            <li>Checkout the <kbd id="connector-repository-tag"></kbd> tag.</li>
+            <li>Modify <kbd>version</kbd> field inside <kbd>Cargo.toml</kbd> to <kbd id="connector-cargo-version"></kbd>.</li>
+            <li>Modify <kbd>DISTRIBUTION_VERSION</kbd> variable inside <kbd>userchrome/profile/chrome/pwa/chrome.jsm</kbd> to <kbd id="connector-userchrome-version"></kbd>.</li>
+            <li>Build the project in release mode:<br /><kbd>cargo build --release</kbd></li>
+            <li>Copy the built files to the correct locations:
+              <ul>
+                <li><kbd>target/release/firefoxpwa</kbd> → <kbd>/usr/local/bin/firefoxpwa</kbd></li>
+                <li><kbd>target/release/firefoxpwa-connector</kbd> → <kbd>/usr/local/libexec/firefoxpwa-connector</kbd></li>
+                <li><kbd>manifests/macos.json</kbd> → <kbd>/Library/Application Support/Mozilla/NativeMessagingHosts/firefoxpwa.json</kbd></li>
+                <li><kbd>userchrome/</kbd> → <kbd>/usr/local/share/firefoxpwa/userchrome/</kbd></li>
+              </ul>
+            </li>
+            <li>
+              Create an empty directory <kbd>/usr/local/share/firefoxpwa/runtime/</kbd> and make it writable by normal users (<kbd>777</kbd>).
+              This is needed for FirefoxPWA runtime installation and Firefox auto-updates to work.
+              If you do not plan to use Firefox auto-updates, you can restore the permissions after the runtime is installed.
+            </li>
+            <li>After the files are copied, you should be automatically proceeded to the next step. If nothing changes after around 30 seconds, restart the browser.</li>
+          </ol>
+          <p>For a list of commands to do this, check <a href="https://github.com/filips123/FirefoxPWA/tree/main/native#macos">the README file in the repository</a>.</p>
         </div>
         <div class="tab-pane fade" id="other-install-pane" role="tabpanel" aria-labelledby="other-install-tab">
           <p>

--- a/extension/src/setup/instructions.html
+++ b/extension/src/setup/instructions.html
@@ -42,9 +42,9 @@
         <div class="tab-pane fade" id="linux-source-install-pane" role="tabpanel" aria-labelledby="linux-source-install-tab">
           <ol>
             <li>Clone the <a href="https://github.com/filips123/FirefoxPWA">FirefoxPWA Git repository</a> and <kbd>cd</kbd> into the <kbd>native</kbd> directory.</li>
-            <li>Checkout the <kbd id="connector-repository-tag"></kbd> tag.</li>
-            <li>Modify <kbd>version</kbd> field inside <kbd>Cargo.toml</kbd> to <kbd id="connector-cargo-version"></kbd>.</li>
-            <li>Modify <kbd>DISTRIBUTION_VERSION</kbd> variable inside <kbd>userchrome/profile/chrome/pwa/chrome.jsm</kbd> to <kbd id="connector-userchrome-version"></kbd>.</li>
+            <li>Checkout the <kbd class="connector-repository-tag"></kbd> tag.</li>
+            <li>Modify <kbd>version</kbd> field inside <kbd>Cargo.toml</kbd> to <kbd class="connector-project-version"></kbd>.</li>
+            <li>Modify <kbd>DISTRIBUTION_VERSION</kbd> variable inside <kbd>userchrome/profile/chrome/pwa/chrome.jsm</kbd> to <kbd class="connector-project-version"></kbd>.</li>
             <li>Build the project in release mode:<br /><kbd>cargo build --release</kbd></li>
             <li>Copy the built files to the correct locations:
               <ul>
@@ -68,14 +68,14 @@
           <p>⚠️ On macOS there is no automatic installer yet. The connector has to be built from source! ⚠️</p>
           <p>
             ⚠️ macOS is not yet fully supported!
-            There is currently no proper system integration (**no** Icon in your application list, **no** correct icon when you launch the PWA, windows are **not** seperated by PWA).
-            Follow #33 to get updated on this issue. ⚠️
+            There is currently no proper system integration (<strong>no</strong> icon in your application list, <strong>no</strong> correct window icon when you launch the PWA, windows are <strong>not</strong> seperated by PWA).
+            Follow <a href="https://github.com/filips123/FirefoxPWA/issues/33" target="_blank">#33</a> for updates about macOS support. ⚠️
           </p>
           <ol>
             <li>Clone the <a href="https://github.com/filips123/FirefoxPWA">FirefoxPWA Git repository</a> and <kbd>cd</kbd> into the <kbd>native</kbd> directory.</li>
-            <li>Checkout the <kbd id="connector-repository-tag"></kbd> tag.</li>
-            <li>Modify <kbd>version</kbd> field inside <kbd>Cargo.toml</kbd> to <kbd id="connector-cargo-version"></kbd>.</li>
-            <li>Modify <kbd>DISTRIBUTION_VERSION</kbd> variable inside <kbd>userchrome/profile/chrome/pwa/chrome.jsm</kbd> to <kbd id="connector-userchrome-version"></kbd>.</li>
+            <li>Checkout the <kbd class="connector-repository-tag"></kbd> tag.</li>
+            <li>Modify <kbd>version</kbd> field inside <kbd>Cargo.toml</kbd> to <kbd class="connector-project-version"></kbd>.</li>
+            <li>Modify <kbd>DISTRIBUTION_VERSION</kbd> variable inside <kbd>userchrome/profile/chrome/pwa/chrome.jsm</kbd> to <kbd class="connector-project-version"></kbd>.</li>
             <li>Build the project in release mode:<br /><kbd>cargo build --release</kbd></li>
             <li>Copy the built files to the correct locations:
               <ul>

--- a/extension/src/setup/instructions.js
+++ b/extension/src/setup/instructions.js
@@ -26,10 +26,9 @@ async function prepareInstallInstructions () {
   // TODO: Set RPM download URL based on system arch and extension version
   // For ARM it doesn't matter which version we set because RPM tab will be hidden later
 
-  // Set repository info based on system arch and extension version
-  document.getElementById('connector-repository-tag').innerText = `v${version}`
-  document.getElementById('connector-cargo-version').innerText = version
-  document.getElementById('connector-userchrome-version').innerText = version
+  // Set repository info based on extension version
+  for (const elem of document.getElementsByClassName('connector-repository-tag')) elem.innerText = `v${version}`
+  for (const elem of document.getElementsByClassName('connector-project-version')) elem.innerText = version
 
   // Hide DEB and RPM tabs on ARM
   // And rename "Other Linux" to just "Linux"

--- a/extension/src/setup/update.scss
+++ b/extension/src/setup/update.scss
@@ -9,7 +9,7 @@
 //////////////////////////////
 
 .wrapper {
-  max-width: 64rem;
+  max-width: 67rem;
 }
 
 .card {

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -116,6 +116,16 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -441,6 +451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dmg"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e565b39e64e4030c75320536cc18cd51f0636811c53d98a05f01ec5deb8dd8f"
+dependencies = [
+ "log 0.3.9",
+ "plist",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,11 +521,12 @@ dependencies = [
  "const_format",
  "data-url",
  "directories",
+ "dmg",
  "fs_extra",
  "gag",
  "glob",
  "image",
- "log",
+ "log 0.4.14",
  "phf 0.9.0",
  "reqwest",
  "runas",
@@ -895,6 +916,15 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.14",
+]
+
+[[package]]
+name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
@@ -970,7 +1000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.14",
  "miow",
  "ntapi",
  "winapi",
@@ -993,7 +1023,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.14",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1248,6 +1278,18 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "plist"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61ac2afed2856590ae79d6f358a24b85ece246d2aa134741a66d589519b7503"
+dependencies = [
+ "base64 0.8.0",
+ "byteorder",
+ "chrono",
+ "xml-rs",
+]
 
 [[package]]
 name = "png"
@@ -1614,7 +1656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1626,7 +1668,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "mime 0.3.16",
  "native-tls",
  "percent-encoding",
@@ -1670,6 +1712,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safemem"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 
 [[package]]
 name = "sanitize-filename"
@@ -1799,7 +1847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d0fe306a0ced1c88a58042dc22fc2ddd000982c26d75f6aa09a394547c41e0"
 dependencies = [
  "chrono",
- "log",
+ "log 0.4.14",
  "termcolor",
 ]
 
@@ -2040,7 +2088,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
+ "log 0.4.14",
  "pin-project-lite",
  "tokio",
 ]
@@ -2162,7 +2210,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log",
+ "log 0.4.14",
  "try-lock",
 ]
 
@@ -2198,7 +2246,7 @@ checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log",
+ "log 0.4.14",
  "proc-macro2",
  "quote",
  "syn",
@@ -2371,4 +2419,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
+dependencies = [
+ "bitflags",
 ]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -56,6 +56,9 @@ bzip2 = "0.4.3"
 phf = { version = "0.9.0", features = ["macros"] }
 tar = "0.4.35"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+dmg = "0.1.1"
+
 [build-dependencies]
 clap = "2.33.3"
 structopt = "0.3.22"

--- a/native/manifests/macos.json
+++ b/native/manifests/macos.json
@@ -1,0 +1,9 @@
+{
+  "name": "firefoxpwa",
+  "description": "The native part of the FirefoxPWA project",
+  "path": "/usr/local/libexec/firefoxpwa-connector",
+  "type": "stdio",
+  "allowed_extensions": [
+    "firefoxpwa@filips.si"
+  ]
+}

--- a/native/src/directories.rs
+++ b/native/src/directories.rs
@@ -26,7 +26,7 @@ impl ProjectDirs {
                 } else if #[cfg(target_os = "linux")] {
                     PathBuf::from("/usr/share/firefoxpwa")
                 } else if #[cfg(target_os = "macos")] {
-                    compile_error!("macOS is currently not supported")
+                    PathBuf::from("/usr/local/share/firefoxpwa")
                 } else {
                     compile_error!("Unknown operating system")
                 }
@@ -38,7 +38,7 @@ impl ProjectDirs {
             let appdata = base.data_dir();
 
             cfg_if! {
-                if #[cfg(target_os = "linux")] { appdata.join("firefoxpwa") }
+                if #[cfg(any(target_os = "linux", target_os = "macos"))] { appdata.join("firefoxpwa") }
                 else { appdata.join("FirefoxPWA") }
             }
         };


### PR DESCRIPTION
Closes #30. 

This does not yet update the installation instructions for macOS. 
I'm not sure what the best way for installation on macOS would be. Installing via Homebrew would probably be the most convenient way for many people. I have no idea what submitting this project to Homebrew would involve, though.  Providing a prebuilt ZIP file with all the necessary binaries and assets might also work well enough.